### PR TITLE
Fixed SMS backends and e-mail template send method

### DIFF
--- a/pymess/backend/sms/ats_sms_operator.py
+++ b/pymess/backend/sms/ats_sms_operator.py
@@ -115,7 +115,6 @@ class ATSSMSBackend(SMSBackend):
             'validity': self.config.VALIDITY,
             'kw': self.config.PROJECT_KEYWORD,
             'textid': self.config.TEXTID,
-            'sender_state': None
         }
 
     def _get_extra_message_kwargs(self):
@@ -201,11 +200,11 @@ class ATSSMSBackend(SMSBackend):
             sms = messages_dict[uniq]
             state = self.ATS_STATES_MAPPING.get(ats_state)
             error = self.ATS_STATES.get_label(ats_state) if state == OutputSMSMessage.STATE.ERROR else None
-            sms.extra_sender_data['sender_state'] = ats_state
             self.update_message(
                 sms,
                 state=state,
                 error=error,
+                extra_sender_data={'sender_state': ats_state}
                 **change_sms_kwargs
             )
 

--- a/pymess/backend/sms/sms_operator.py
+++ b/pymess/backend/sms/sms_operator.py
@@ -80,7 +80,6 @@ class SMSOperatorBackend(SMSBackend):
     def _get_extra_sender_data(self):
         return {
             'prefix': self.config.UNIQ_PREFIX,
-            'sender_state': None
         }
 
     def _serialize_messages(self, messages, request_type):
@@ -157,11 +156,11 @@ class SMSOperatorBackend(SMSBackend):
                 self.SMS_OPERATOR_STATES.get_label(sms_operator_state)
                 if state == OutputSMSMessage.STATE.ERROR else None
             )
-            sms.extra_sender_data['sender_state'] = sms_operator_state
             self.update_message(
                 sms,
                 state=state,
                 error=error,
+                extra_sender_data={'sender_state': sms_operator_state},
                 **change_sms_kwargs
             )
 

--- a/pymess/config.py
+++ b/pymess/config.py
@@ -9,7 +9,7 @@ DEFAULTS = {
     # SMS configuration
     'SMS_TEMPLATE_MODEL': 'pymess.SMSTemplate',
     'SMS_ATS_CONFIG': {
-        'UNIQ_PREFIX': 'test',
+        'UNIQ_PREFIX': '',
         'VALIDITY': 60,
         'TEXTID': None,
         'URL': 'http://fik.atspraha.cz/gwfcgi/XMLServerWrapper.fcgi',
@@ -17,7 +17,7 @@ DEFAULTS = {
     },
     'SMS_OPERATOR_CONFIG': {
         'URL': 'https://www.sms-operator.cz/webservices/webservice.aspx',
-        'UNIQ_PREFIX': 'test',
+        'UNIQ_PREFIX': '',
     },
     'SMS_SNS_CONFIG': {
     },

--- a/pymess/models/emails.py
+++ b/pymess/models/emails.py
@@ -166,6 +166,7 @@ class AbstractEmailTemplate(SmartModel):
                 recipient,
                 self.render_subject(context_data),
                 self.render_body(context_data),
+                sender_name=self.sender_name,
                 related_objects=related_objects,
                 tag=tag,
                 template=self,


### PR DESCRIPTION
ATS SMS backend and SMS operator backend has invalid update SMS message parameters.

E-mail template sned methods doesn't set sender name