### PR TITLE
Remove re-raising caught exception from 'publish_message' methods

### DIFF
--- a/pymess/backend/dialer/daktela.py
+++ b/pymess/backend/dialer/daktela.py
@@ -84,7 +84,9 @@ class DaktelaDialerBackend(DialerBackend):
                 )
             except Exception as ex:
                 self.update_message(message, state=DialerMessage.STATE.ERROR, error=force_text(ex))
-                raise ex
+                # Do not re-raise caught exception. We do not know exact exception to catch so we catch them all
+                # and log them into database. Re-raise exception causes transaction rollback (lost of information about
+                # exception).
 
     def publish_message(self, message):
         """
@@ -128,4 +130,6 @@ class DaktelaDialerBackend(DialerBackend):
             )
         except Exception as ex:
             self.update_message(message, state=DialerMessage.STATE.ERROR, error=force_text(ex))
-            raise ex
+            # Do not re-raise caught exception. We do not know exact exception to catch so we catch them all
+            # and log them into database. Re-raise exception causes transaction rollback (lost of information about
+            # exception).

--- a/pymess/backend/emails/mandrill.py
+++ b/pymess/backend/emails/mandrill.py
@@ -83,4 +83,5 @@ class MandrillEmailBackend(EmailBackend):
                                 extra_sender_data=extra_sender_data, error=error)
         except (mandrill.Error, JSONDecodeError, requests.exceptions.RequestException) as ex:
             self.update_message(message, state=EmailMessage.STATE.ERROR, error=force_text(ex))
-            raise ex
+            # Do not re-raise caught exception. Re-raise exception causes transaction rollback (lost of information
+            # about exception).

--- a/pymess/backend/emails/smtp.py
+++ b/pymess/backend/emails/smtp.py
@@ -32,4 +32,6 @@ class SMTPEmailBackend(EmailBackend):
             self.update_message(message, state=EmailMessage.STATE.SENT, sent_at=timezone.now())
         except Exception as ex:
             self.update_message(message, state=EmailMessage.STATE.ERROR, error=force_text(ex))
-            raise ex
+            # Do not re-raise caught exception. We do not know exact exception to catch so we catch them all
+            # and log them into database. Re-raise exception causes transaction rollback (lost of information about
+            # exception).

--- a/pymess/backend/sms/sns.py
+++ b/pymess/backend/sms/sns.py
@@ -54,4 +54,6 @@ class SNSSMSBackend(SMSBackend):
             self.update_message(message, state=OutputSMSMessage.STATE.SENT, sent_at=timezone.now())
         except Exception as ex:
             self.update_message(message, state=OutputSMSMessage.STATE.ERROR, error=force_text(ex))
-            raise ex
+            # Do not re-raise caught exception. We do not know exact exception to catch so we catch them all
+            # and log them into database. Re-raise exception causes transaction rollback (lost of information about
+            # exception).

--- a/pymess/backend/sms/twilio.py
+++ b/pymess/backend/sms/twilio.py
@@ -68,4 +68,6 @@ class TwilioSMSBackend(SMSBackend):
             )
         except Exception as ex:
             self.update_message(message, state=OutputSMSMessage.STATE.ERROR, error=force_text(ex))
-            raise ex
+            # Do not re-raise caught exception. We do not know exact exception to catch so we catch them all
+            # and log them into database. Re-raise exception causes transaction rollback (lost of information about
+            # exception).


### PR DESCRIPTION
Re-raising exception after saving it into DB will cause lost of information
due to transaction rollback on exception.