### PR TITLE
SNS: rename config name settings

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -81,18 +81,6 @@ SMS
 
    Defines maximum number of seconds to try to send a SMS message that ended in an ``ERROR_RETRY`` state. Default value is ``60 * 60`` (1 hour).
 
-.. attribute:: PYMESS_SMS_ATS_CONFIG
-
-  Configuration of ``pymess.backend.sms.ats_sms_operator.ATSSMSBackend``.
-
-.. attribute:: PYMESS_SMS_OPERATOR_CONFIG
-
-  Configuration of ``pymess.backend.sms.sms_operator.SMSOperatorBackend``.
-
-.. attribute:: PYMESS_SMS_SNS_CONFIG
-
-  Configuration of ``pymess.backend.sms.sns.SNSSMSBackend``.
-
 E-MAIL
 ^^^^^^
 
@@ -152,10 +140,6 @@ E-MAIL
 
   Defines delay in seconds from the time the message change notification was received to message info will be pulled from the provider.
 
-.. attribute:: PYMESS_EMAIL_MANDRILL
-
-  Configuration of ``pymess.backend.email.mandrill.MandrillEmailBackend``.
-
 
 DIALER
 ^^^^^^
@@ -192,9 +176,6 @@ DIALER
 
   Number of check attempts to get dialer message state. Default value is ``5``
 
-.. attribute:: PYMESS_DIALER_DAKTELA
-
-  Configuration of ``pymess.backend.dialer.daktela.DaktelaDialerBackend``.
 
 Push notifications
 ^^^^^^^^^^^^^^^^^^
@@ -222,7 +203,3 @@ Push notifications
 .. attribute:: PYMESS_PUSH_NOTIFICATION_BATCH_MAX_SECONDS_TO_SEND
 
   Defines maximum number of seconds to try to send an push notification message that ended in an ``ERROR_RETRY`` state. Default value is ``60 * 60`` (1 hour).
-
-.. attribute:: PUSH_NOTIFICATION_ONESIGNAL
-
-  Configuration of ``pymess.backend.push.onesignal.OneSignalPushNotificationBackend``.

--- a/docs/push.rst
+++ b/docs/push.rst
@@ -188,7 +188,7 @@ Backend is a class that is used for sending messages. Every backend must provide
 
   Configuration of attributes according to push notification operator documentation::
 
-    PYMESS_PUSH_NOTIFICATION_ONESIGNAL = {
+    config = {
         'APP_ID': 'app-id',
         'API_KEY': 'api-key,
         'LANGUAGE': 'language',

--- a/pymess/backend/__init__.py
+++ b/pymess/backend/__init__.py
@@ -1,20 +1,157 @@
+from attrdict import AttrDict
+from collections import OrderedDict, defaultdict
 from datetime import timedelta
 
 from django.db import transaction
-from django.db.models import Q
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _l
 from django.utils.timezone import now
 
 from pymess.config import settings
+from pymess.config import get_router, get_backend, get_default_sender_backend_name
 from pymess.utils import fullname
+
+
+class BaseController:
+    """
+    Base class of Controller. Any type of communication requires Controller derived from this class.
+    Many backends of the same type of communication can be supported by one controller which chooses the right backend
+    implementation based on the recipient
+    """
+
+    model = None
+    backend_type_name = None
+
+    def __init__(self):
+        self._loaded_backends = {}
+
+    def get_backend(self, recipient):
+        backend_name = self.router.get_backend_name(recipient) or get_default_sender_backend_name(self.backend_type_name)
+        if backend_name not in self._loaded_backends:
+            self._loaded_backends[backend_name] = get_backend(self.backend_type_name, backend_name)
+        return self._loaded_backends[backend_name]
+
+    @cached_property
+    def router(self):
+        return get_router(self.backend_type_name)
+
+    def get_waiting_or_retry_messages(self):
+        """
+        Return queryset of waiting messages to send
+        """
+        return self.model.objects.filter(state__in={self.model.STATE.WAITING, self.model.STATE.ERROR_RETRY})
+
+    def is_turned_on_batch_sending(self):
+        return False
+
+    def publish_or_retry_message(self, message):
+        backend = self.get_backend(recipient=message.recipient)
+        if (message.number_of_send_attempts > backend.get_batch_max_number_of_send_attempts()
+            or message.created_at < now() - timedelta(seconds=self.get_batch_max_seconds_to_send())):
+            backend._set_message_as_failed(message)
+            return False
+        else:
+            backend.publish_message(message)
+            return True
+
+    @transaction.atomic
+    def send(self, recipient, content, related_objects=None, tag=None, template=None, **kwargs):
+        """
+        Send message with the text content to the phone number (recipient)
+        :param recipient: email or phone number of the recipient
+        :param content: text content of the message
+        :param related_objects: list of related objects that will be linked with the message using generic
+        relation
+        :param tag: string mark that will be saved with the message
+        :param template: template object from which content of the message was create
+        :param kwargs: extra attributes that will be stored to the message
+        """
+        backend = self.get_backend(recipient)
+        message = self.create_message(recipient, content, related_objects, tag, template, **kwargs)
+        if not self.is_turned_on_batch_sending():
+            backend.publish_message(message)
+        return message
+
+    def get_batch_max_seconds_to_send(self):
+        """
+        Return max timeout in seconds to send message
+        """
+        raise NotImplementedError
+
+    def get_batch_size(self):
+        """
+        Return number of messages sent in batch
+        """
+        raise NotImplementedError
+
+    def create_message(self, recipient, content, related_objects, tag, template,
+                       priority=settings.DEFAULT_MESSAGE_PRIORITY, **kwargs):
+        """
+        Create message which will be logged in the database.
+        :param recipient: email or phone number of the recipient
+        :param content: content of the message
+        :param related_objects: list of related objects that will be linked with the message using generic
+        relation
+        :param tag: string mark that will be saved with the message
+        :param template: template object from which content of the message was created
+        :param priority: priority of sending message 1 (highest) to 3 (lowest)
+        :param kwargs: extra attributes that will be saved with the message
+        """
+        message = self.model.objects.create(
+            recipient=recipient,
+            content=content,
+            tag=tag,
+            template=template,
+            template_slug=template.slug if template else None,
+            priority=priority,
+            **kwargs
+        )
+        if related_objects:
+            message.related_objects.create_from_related_objects(*related_objects)
+        return message
+
+    def _get_backend_messages_map(self, messages):
+        backends_messages_map = defaultdict(list)
+        for message in messages:
+            backend = self.get_backend(recipient=message.recipient)
+            backends_messages_map[backend].append(message)
+        return backends_messages_map
+
+    def bulk_send_messages(self, messages):
+        """
+        Sends more messages together. If concrete backend provides send more messages at once the method
+        can be overridden
+        :param messages: list of messages
+        """
+        for backend, messages_for_backend in self._get_backend_messages_map(messages):
+            backend.publish_messages(messages_for_backend)
+
+    def bulk_send(self, recipients, content, related_objects=None, tag=None, template=None, **kwargs):
+        """
+        Send more messages in one bulk
+        :param recipients: list of emails or phone numbers of recipients
+        :param content: text content of the messages
+        :param related_objects: list of related objects that will be linked with the message using generic
+        relation
+        :param tag: string mark that will be saved with the message
+        :param template: template object from which content of the message was create
+        :param kwargs: extra attributes that will be stored with messages
+        """
+        with transaction.atomic():
+            messages = [
+                self.create_message(recipient, content, related_objects, tag, template, **kwargs)
+                for recipient in recipients
+            ]
+        self.bulk_send_messages(messages)
+        return messages
 
 
 class BaseBackend:
 
-    model = None
+    config = AttrDict()
 
-    def __init__(self):
-        assert self.model is not None, _l('self.model cannot be None')
+    def __init__(self, config=None):
+        self.config = AttrDict({**self.config, **(config or {})})
 
     def _get_extra_sender_data(self):
         """
@@ -22,7 +159,7 @@ class BaseBackend:
         """
         return {}
 
-    def _get_extra_message_kwargs(self):
+    def get_extra_message_kwargs(self):
         """
         Gets model message kwargs that will be saved with the message
         """
@@ -72,10 +209,10 @@ class BaseBackend:
 
         if not state:
             state = (
-                self.model.STATE.ERROR if (
-                        number_of_send_attempts > self.get_batch_max_number_of_send_attempts()
-                        or not self.get_retry_sending()
-                ) else self.model.STATE.ERROR_RETRY
+                message.STATE.ERROR if (
+                    number_of_send_attempts > self.get_batch_max_number_of_send_attempts()
+                    or not self.get_retry_sending()
+                ) else message.STATE.ERROR_RETRY
             )
 
         self._update_message(
@@ -93,45 +230,8 @@ class BaseBackend:
         """
         self._update_message(
             message,
-            state=self.model.STATE.ERROR,
+            state=message.STATE.ERROR,
         )
-
-    def create_message(self, recipient, content, related_objects, tag, template,
-                       priority=settings.DEFAULT_MESSAGE_PRIORITY, **kwargs):
-        """
-        Create message which will be logged in the database.
-        :param recipient: email or phone number of the recipient
-        :param content: content of the message
-        :param related_objects: list of related objects that will be linked with the message using generic
-        relation
-        :param tag: string mark that will be saved with the message
-        :param template: template object from which content of the message was created
-        :param kwargs: extra attributes that will be saved with the message
-        """
-        message = self.model.objects.create(
-            recipient=recipient,
-            content=content,
-            tag=tag,
-            template=template,
-            template_slug=template.slug if template else None,
-            priority=priority,
-            **kwargs
-        )
-        if related_objects:
-            message.related_objects.create_from_related_objects(*related_objects)
-        return message
-
-    def is_turned_on_batch_sending(self):
-        return False
-
-    def publish_or_retry_message(self, message):
-        if (message.number_of_send_attempts > self.get_batch_max_number_of_send_attempts()
-                or message.created_at < now() - timedelta(seconds=self.get_batch_max_seconds_to_send())):
-            self._set_message_as_failed(message)
-            return False
-        else:
-            self.publish_message(message)
-            return True
 
     def publish_message(self, message):
         """
@@ -140,11 +240,12 @@ class BaseBackend:
         """
         raise NotImplementedError
 
-    def get_batch_size(self):
+    def publish_messages(self, messages):
         """
-        Return number of messages sent in batch
+        Send bulk of messages at once
+        :param messages: list of SMS message
         """
-        raise NotImplementedError
+        return [self.publish_message(message) for message in sorted(messages, key=lambda m: m.priority)]
 
     def get_batch_max_number_of_send_attempts(self):
         """
@@ -152,67 +253,11 @@ class BaseBackend:
         """
         raise NotImplementedError
 
-    def get_batch_max_seconds_to_send(self):
-        """
-        Return max timeout in seconds to send message
-        """
-        raise NotImplementedError
-
-    def get_waiting_or_retry_messages(self):
-        """
-        Return queryset of waiting messages to send
-        """
-        return self.model.objects.filter(state__in={self.model.STATE.WAITING, self.model.STATE.ERROR_RETRY})
-
     def get_retry_sending(self):
         """
         Return True if message should be retried if sending fails
         """
         raise NotImplementedError
-
-    def publish_messages(self, messages):
-        """
-        Sends more messages together. If concrete backend provides send more messages at once the method
-        can be overridden
-        :param messages: list of messages
-        """
-        [self.publish_message(message) for message in messages]
-
-    @transaction.atomic
-    def send(self, recipient, content, related_objects=None, tag=None, template=None, **kwargs):
-        """
-        Send message with the text content to the phone number (recipient)
-        :param recipient: email or phone number of the recipient
-        :param content: text content of the message
-        :param related_objects: list of related objects that will be linked with the message using generic
-        relation
-        :param tag: string mark that will be saved with the message
-        :param template: template object from which content of the message was create
-        :param kwargs: extra attributes that will be stored to the message
-        """
-        message = self.create_message(recipient, content, related_objects, tag, template, **kwargs)
-        if not self.is_turned_on_batch_sending():
-            self.publish_message(message)
-        return message
-
-    @transaction.atomic
-    def bulk_send(self, recipients, content, related_objects=None, tag=None, template=None, **kwargs):
-        """
-        Send more messages in one bulk
-        :param recipients: list of emails or phone numbers of recipients
-        :param content: text content of the messages
-        :param related_objects: list of related objects that will be linked with the message using generic
-        relation
-        :param tag: string mark that will be saved with the message
-        :param template: template object from which content of the message was create
-        :param kwargs: extra attributes that will be stored with messages
-        """
-        messages = [
-            self.create_message(recipient, content, related_objects, tag, template, **kwargs)
-            for recipient in recipients
-        ]
-        self.publish_messages(messages)
-        return messages
 
 
 def send_template(recipient, slug, context_data, related_objects=None, tag=None, template_model=None, **kwargs):
@@ -239,7 +284,7 @@ def send_template(recipient, slug, context_data, related_objects=None, tag=None,
     )
 
 
-def send(recipient, content, related_objects=None, tag=None, message_sender=None, **kwargs):
+def send(recipient, content, related_objects=None, tag=None, message_controller=None, **kwargs):
     """
     Helper for sending message.
     :param recipient: email or phone number of the recipient
@@ -247,10 +292,10 @@ def send(recipient, content, related_objects=None, tag=None, message_sender=None
     :param related_objects:
     :param tag: string mark that will be saved with the message
     :param kwargs: extra attributes that will be stored with messages
-    :param message_sender: sender instance 
+    :param message_controller: controller sender instance
     :return: True if message was successfully sent or False if message is in error state
     """
-    return message_sender.send(
+    return message_controller.send(
         recipient,
         content,
         related_objects=related_objects,

--- a/pymess/backend/dialer/__init__.py
+++ b/pymess/backend/dialer/__init__.py
@@ -4,71 +4,33 @@ from datetime import timedelta
 from chamber.exceptions import PersistenceException
 from django.utils.timezone import now
 
-from pymess.backend import BaseBackend
+from pymess.backend import BaseBackend, BaseController
 from pymess.backend import send as _send
 from pymess.backend import send_template as _send_template
-from pymess.config import get_dialer_sender, get_dialer_template_model, settings
+from pymess.config import (
+    CONTROLLER_TYPES, get_dialer_template_model, get_supported_backend_paths, is_turned_on_dialer_batch_sending,
+    settings
+)
 from pymess.models import DialerMessage
-from pymess.utils import fullname
+
 
 LOGGER = logging.getLogger(__name__)
 
 
-class DialerSendingError(Exception):
-    pass
-
-
-class DialerBackend(BaseBackend):
-    """
-    Base class for dialer backend containing implementation of concrete dialer service that
-    is used for automatic call to selected phone number.
-    """
+class DialerController(BaseController):
+    """Controller class for dialer delegating message to correct dialer backend"""
 
     model = DialerMessage
+    backend_type_name = CONTROLLER_TYPES.DIALER
 
-    def is_turned_on_batch_sending(self):
-        return settings.DIALER_BATCH_SENDING
+    class DialerSendingError(Exception):
+        pass
 
     def get_batch_size(self):
         return settings.DIALER_BATCH_SIZE
 
-    def get_batch_max_number_of_send_attempts(self):
-        return settings.DIALER_BATCH_MAX_NUMBER_OF_SEND_ATTEMPTS
-
     def get_batch_max_seconds_to_send(self):
         return settings.DIALER_BATCH_MAX_SECONDS_TO_SEND
-
-    def get_retry_sending(self):
-        return settings.DIALER_RETRY_SENDING and self.is_turned_on_batch_sending()
-
-    def create_message(self, recipient, content, related_objects, tag, template, is_autodialer=True,
-                       priority=settings.DEFAULT_MESSAGE_PRIORITY, **kwargs):
-        """
-        Create dialer message which will be logged in the database.
-        :param recipient: phone number of the recipient
-        :param content: content of the dialer message
-        :param related_objects: list of related objects that will be linked with the dialer message using generic
-        relation
-        :param tag: string mark that will be saved with the message
-        :param template: template object from which content of the message was created
-        :param is_autodialer: True if it's a autodialer call otherwise False
-        :param kwargs: extra attributes that will be saved with the message
-        """
-        try:
-            return super().create_message(
-                recipient,
-                content,
-                related_objects,
-                tag,
-                template,
-                state=self.get_initial_dialer_state(recipient),
-                is_autodialer=is_autodialer,
-                priority=priority,
-                extra_data=kwargs,
-                **self._get_extra_message_kwargs()
-            )
-        except PersistenceException as ex:
-            raise DialerSendingError(str(ex))
 
     def get_initial_dialer_state(self, recipient):
         """
@@ -77,12 +39,35 @@ class DialerBackend(BaseBackend):
         """
         return self.model.STATE.WAITING
 
-    def _update_dialer_states(self, messages):
+    def create_message(self, recipient, content=None, related_objects=None, tag=None, template=None, is_autodialer=True,
+                       priority=settings.DEFAULT_MESSAGE_PRIORITY, **kwargs):
         """
-        If dialer sender provides check dialer delivery this method can be overridden.
-        :param messages: messages which state will be updated
+        Create dialer message which will be logged in the database (content is not needed for this).
+        :param recipient: phone number of the recipient
+        :param related_objects: list of related objects that will be linked with the dialer message using generic
+        relation
+        :param tag: string mark that will be saved with the message
+        :param template: template object from which content of the message was created
+        :param is_autodialer: True if it's a autodialer call otherwise False
+        :param priority: priority of sending message 1 (highest) to 3 (lowest)
+        :param kwargs: extra attributes that will be saved with the message
         """
-        raise NotImplementedError('Check dialer state is not supported with the backend')
+        extra_data = kwargs.pop('extra_data', {})
+        try:
+            return super().create_message(
+                recipient=recipient,
+                content=content,
+                related_objects=related_objects,
+                tag=tag,
+                template=template,
+                state=self.get_initial_dialer_state(recipient),
+                is_autodialer=is_autodialer,
+                priority=priority,
+                extra_data=kwargs,
+                **self.get_backend(recipient).get_extra_message_kwargs(),
+            )
+        except PersistenceException as ex:
+            raise self.DialerSendingError(str(ex))
 
     def bulk_check_dialer_status(self):
         """
@@ -91,11 +76,35 @@ class DialerBackend(BaseBackend):
         messages_to_check = self.model.objects.filter(
             is_final_state=False,
             sent_at__isnull=False,
-            backend=fullname(self),
+            backend__in=get_supported_backend_paths(self.backend_type_name),
             created_at__gte=now() - timedelta(minutes=settings.DIALER_IDLE_MESSAGES_TIMEOUT_MINUTES),
         )
         if messages_to_check.exists():
-            self._update_dialer_states(messages_to_check)
+            for backend, messages_for_backend in self._get_backend_messages_map(messages_to_check):
+                backend._update_dialer_states(messages_to_check)
+
+    def is_turned_on_batch_sending(self):
+        return is_turned_on_dialer_batch_sending()
+
+
+class DialerBackend(BaseBackend):
+    """
+    Base class for dialer backend containing implementation of concrete dialer service that
+    is used for automatic call to selected phone number.
+    """
+
+    def get_batch_max_number_of_send_attempts(self):
+        return settings.DIALER_BATCH_MAX_NUMBER_OF_SEND_ATTEMPTS
+
+    def get_retry_sending(self):
+        return settings.DIALER_RETRY_SENDING and is_turned_on_dialer_batch_sending()
+
+    def _update_dialer_states(self, messages):
+        """
+        If dialer sender provides check dialer delivery this method can be overridden.
+        :param messages: messages which state will be updated
+        """
+        raise NotImplementedError('Check dialer state is not supported with the backend')
 
 
 def send_template(recipient, slug, context_data, related_objects=None, tag=None):
@@ -134,6 +143,6 @@ def send(recipient, content, related_objects=None, tag=None, **kwargs):
         content,
         related_objects,
         tag,
-        message_sender=get_dialer_sender(),
+        message_controller=DialerController(),
         **kwargs
     )

--- a/pymess/backend/dialer/dummy.py
+++ b/pymess/backend/dialer/dummy.py
@@ -10,4 +10,5 @@ class DummyDialerBackend(DialerBackend):
     """
 
     def publish_message(self, message):
-        self._update_message_after_sending(message, state=DialerMessage.STATE.DEBUG, sent_at=timezone.now())
+        self._update_message_after_sending(message, state=DialerMessage.STATE.DEBUG, sent_at=timezone.now(),
+                                           is_final_state=True)

--- a/pymess/backend/emails/__init__.py
+++ b/pymess/backend/emails/__init__.py
@@ -1,20 +1,33 @@
 from chamber.exceptions import PersistenceException
 
-from pymess.backend import BaseBackend, send_template as _send_template, send as _send
-from pymess.config import get_email_template_model, get_email_sender, settings
+from pymess.backend import BaseBackend, send_template as _send_template, BaseController
+from pymess.config import (
+    CONTROLLER_TYPES, get_email_template_model, is_turned_on_email_batch_sending, settings,
+)
 from pymess.models import EmailMessage
 
 
-class EmailBackend(BaseBackend):
-    """
-    Base class for E-mail backend containing implementation of e-mail service that
-    is used for sending messages.
-    """
+class EmailController(BaseController):
+    """Controller class for E-mail delegating message to correct E-mail backend"""
 
     model = EmailMessage
+    backend_type_name = CONTROLLER_TYPES.EMAIL
 
     class EmailSendingError(Exception):
         pass
+
+    def get_batch_size(self):
+        return settings.EMAIL_BATCH_SIZE
+
+    def get_batch_max_seconds_to_send(self):
+        return settings.EMAIL_BATCH_MAX_SECONDS_TO_SEND
+
+    def get_initial_email_state(self, recipient):
+        """
+        returns initial state for logged e-mail message.
+        :param recipient: e-mail address of the recipient
+        """
+        return self.model.STATE.WAITING
 
     def create_message(self, sender, sender_name, recipient, subject, content, related_objects, tag, template,
                        attachments, priority=settings.DEFAULT_MESSAGE_PRIORITY, **kwargs):
@@ -30,6 +43,7 @@ class EmailBackend(BaseBackend):
         :param tag: string mark that will be saved with the message
         :param template: template object from which content, subject and sender of the message was created
         :param attachments: list of files that will be sent with the message as attachments
+        :param priority: priority of sending message 1 (highest) to 3 (lowest)
         :param kwargs: extra data that will be saved in JSON format in the extra_data model field
         """
         try:
@@ -45,28 +59,13 @@ class EmailBackend(BaseBackend):
                 state=self.get_initial_email_state(recipient),
                 priority=priority,
                 extra_data=kwargs,
-                **self._get_extra_message_kwargs()
+                **self.get_backend(recipient).get_extra_message_kwargs()
             )
             if attachments:
                 message.attachments.create_from_tripples(*attachments)
             return message
         except PersistenceException as ex:
             raise self.EmailSendingError(str(ex))
-
-    def is_turned_on_batch_sending(self):
-        return settings.EMAIL_BATCH_SENDING
-
-    def get_batch_max_number_of_send_attempts(self):
-        return settings.EMAIL_BATCH_MAX_NUMBER_OF_SEND_ATTEMPTS
-
-    def get_batch_max_seconds_to_send(self):
-        return settings.EMAIL_BATCH_MAX_SECONDS_TO_SEND
-
-    def get_batch_size(self):
-        return settings.EMAIL_BATCH_SIZE
-
-    def get_retry_sending(self):
-        return settings.EMAIL_RETRY_SENDING and self.is_turned_on_batch_sending()
 
     def send(self, sender, recipient, subject, content, sender_name=None, related_objects=None, tag=None,
              template=None, attachments=None, **kwargs):
@@ -87,16 +86,26 @@ class EmailBackend(BaseBackend):
         message = self.create_message(
             sender, sender_name, recipient, subject, content, related_objects, tag, template, attachments, **kwargs
         )
+        backend = self.get_backend(message.recipient)
         if not self.is_turned_on_batch_sending():
-            self.publish_message(message)
+            backend.publish_message(message)
         return message
 
-    def get_initial_email_state(self, recipient):
-        """
-        returns initial state for logged e-mail message.
-        :param recipient: e-mail address of the recipient
-        """
-        return self.model.STATE.WAITING
+    def is_turned_on_batch_sending(self):
+        return is_turned_on_email_batch_sending()
+
+
+class EmailBackend(BaseBackend):
+    """
+    Base class for E-mail backend containing implementation of e-mail service that
+    is used for sending messages.
+    """
+
+    def get_batch_max_number_of_send_attempts(self):
+        return settings.EMAIL_BATCH_MAX_NUMBER_OF_SEND_ATTEMPTS
+
+    def get_retry_sending(self):
+        return settings.EMAIL_RETRY_SENDING and is_turned_on_email_batch_sending()
 
     def pull_message_info(self, message):
         """
@@ -145,7 +154,7 @@ def send(sender, recipient, subject, content, sender_name=None, related_objects=
     :param email_kwargs: extra data that will be saved in JSON format in the extra_data model field
     :return: True if e-mail was successfully sent or False if e-mail is in error state
     """
-    return get_email_sender().send(
+    return EmailController().send(
         sender=sender,
         recipient=recipient,
         subject=subject,

--- a/pymess/backend/emails/dummy.py
+++ b/pymess/backend/emails/dummy.py
@@ -1,7 +1,6 @@
 from django.utils import timezone
 
 from pymess.backend.emails import EmailBackend
-from pymess.models import EmailMessage
 
 
 class DummyEmailBackend(EmailBackend):
@@ -10,7 +9,7 @@ class DummyEmailBackend(EmailBackend):
     """
 
     def publish_message(self, message):
-        self._update_message_after_sending(message, state=EmailMessage.STATE.DEBUG, sent_at=timezone.now())
+        self._update_message_after_sending(message, state=message.STATE.DEBUG, sent_at=timezone.now())
 
     def pull_message_info(self, message):
         self._update_message(

--- a/pymess/backend/emails/smtp.py
+++ b/pymess/backend/emails/smtp.py
@@ -4,7 +4,6 @@ from django.core.mail import EmailMultiAlternatives
 from django.utils import timezone
 
 from pymess.backend.emails import EmailBackend
-from pymess.models import EmailMessage
 
 
 class SMTPEmailBackend(EmailBackend):
@@ -28,7 +27,7 @@ class SMTPEmailBackend(EmailBackend):
             )
         try:
             email_message.send()
-            self._update_message_after_sending(message, state=EmailMessage.STATE.SENT, sent_at=timezone.now())
+            self._update_message_after_sending(message, state=message.STATE.SENT, sent_at=timezone.now())
         except Exception as ex:
             self._update_message_after_sending_error(message, error=str(ex))
             # Do not re-raise caught exception. We do not know exact exception to catch so we catch them all

--- a/pymess/backend/routers.py
+++ b/pymess/backend/routers.py
@@ -1,0 +1,13 @@
+class BaseRouter:
+
+    def get_backend_name(self, recipient):
+        """
+        Method should return name of the backend specified in PYMESS_*_BACKEND_ROUTER setting option
+        """
+        raise NotImplementedError
+
+
+class DefaultBackendRouter(BaseRouter):
+
+    def get_backend_name(self, recipient):
+        return None

--- a/pymess/backend/sms/dummy.py
+++ b/pymess/backend/sms/dummy.py
@@ -1,8 +1,5 @@
-from chamber.shortcuts import change_and_save
 from django.utils import timezone
-
 from pymess.backend.sms import SMSBackend
-from pymess.models import OutputSMSMessage
 
 
 class DummySMSBackend(SMSBackend):
@@ -11,4 +8,4 @@ class DummySMSBackend(SMSBackend):
     """
 
     def publish_message(self, message):
-        self._update_message_after_sending(message, state=OutputSMSMessage.STATE.DEBUG, sent_at=timezone.now())
+        self._update_message_after_sending(message, state=message.STATE.DEBUG, sent_at=timezone.now())

--- a/pymess/backend/sms/sms_operator.py
+++ b/pymess/backend/sms/sms_operator.py
@@ -1,3 +1,4 @@
+from attrdict import AttrDict
 from bs4 import BeautifulSoup
 
 import requests
@@ -75,8 +76,11 @@ class SMSOperatorBackend(SMSBackend):
         SMS_OPERATOR_STATES.NOT_FOUND: OutputSMSMessage.STATE.ERROR_UPDATE,
     }
 
-    def __init__(self):
-        self.config = settings.SMS_OPERATOR_CONFIG
+    config = AttrDict({
+        'URL': 'https://www.sms-operator.cz/webservices/webservice.aspx',
+        'UNIQ_PREFIX': '',
+        'TIMEOUT': 5,  # 5s
+    })
 
     def _get_extra_sender_data(self):
         return {
@@ -223,5 +227,5 @@ class SMSOperatorBackend(SMSBackend):
         return {int(item.smsid.string.lstrip(self.config.UNIQ_PREFIX + '-')): int(item.status.string)
                 for item in soup.find_all('dataitem')}
 
-    def _update_sms_states(self, messages):
+    def update_sms_states(self, messages):
         self._send_requests(messages, request_type=self.REQUEST_TYPES.DELIVERY_REQUEST)

--- a/pymess/backend/sms/sns.py
+++ b/pymess/backend/sms/sns.py
@@ -1,4 +1,5 @@
 import boto3
+from attrdict import AttrDict
 
 from django.conf import settings
 from django.utils import timezone
@@ -14,17 +15,23 @@ class SNSSMSBackend(SMSBackend):
     """
 
     sns_client = None
+    config = AttrDict({
+        'AWS_ACCESS_KEY_ID': None,
+        'AWS_SECRET_ACCESS_KEY': None,
+        'AWS_REGION': None,
+        'SENDER_ID': None,
+    })
 
     def _get_sns_client(self):
         """
         Connect to the SNS service
         """
         if not self.sns_client:
-            boto3.client(
+            self.sns_client = boto3.client(
                 service_name='sns',
-                aws_access_key_id=settings.SNS.AWS_ACCESS_KEY_ID,
-                aws_secret_access_key=settings.SNS.AWS_SECRET_ACCESS_KEY,
-                region_name=settings.SNS.AWS_SMS_REGION,
+                aws_access_key_id=self.config.AWS_ACCESS_KEY_ID,
+                aws_secret_access_key=self.config.AWS_SECRET_ACCESS_KEY,
+                region_name=self.config.AWS_REGION,
                 use_ssl=True
             )
         return self.sns_client
@@ -39,12 +46,12 @@ class SNSSMSBackend(SMSBackend):
             'PhoneNumber': str(message.recipient),
             'Message': message.content,
         }
-        if settings.SNS.SENDER_ID:
+        if self.config.SENDER_ID:
             publish_kwargs.update({
                 'MessageAttributes': {
                     'AWS.SNS.SMS.SenderID': {
                         'DataType': 'String',
-                        'StringValue': settings.SNS.SENDER_ID,
+                        'StringValue': self.config.SENDER_ID,
                     }
                 }
             })

--- a/pymess/management/commands/check_dialer_status.py
+++ b/pymess/management/commands/check_dialer_status.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from pymess.config import get_dialer_sender
+from pymess.backend.dialer import DialerController
 
 
 class Command(BaseCommand):
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **kwargs):
-        get_dialer_sender().bulk_check_dialer_status()
+        DialerController().bulk_check_dialer_status()

--- a/pymess/management/commands/check_sms_delivery.py
+++ b/pymess/management/commands/check_sms_delivery.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from pymess.config import get_sms_sender
+from pymess.backend.sms import bulk_check_sms_states
 
 
 class Command(BaseCommand):
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **kwargs):
-        get_sms_sender().bulk_check_sms_states()
+        bulk_check_sms_states()

--- a/pymess/models/common.py
+++ b/pymess/models/common.py
@@ -170,7 +170,6 @@ class BaseAbstractTemplate(SmartModel):
     is_active = models.BooleanField(null=False, blank=False, default=True, verbose_name=_('is active'))
     is_allowed_duplicate_messages = models.BooleanField(null=False, blank=False, default=True,
                                                         verbose_name=_('Duplicate messages are allowed'))
-
     def _update_context_data(self, context_data):
         return context_data
 
@@ -205,7 +204,7 @@ class BaseAbstractTemplate(SmartModel):
 
     def exist_duplicate_messages(self, related_objects):
         if related_objects:
-            qs = self.get_backend_sender().model.objects.filter(template=self)
+            qs = self.get_controller().model.objects.filter(template=self)
             for obj in related_objects:
                 qs = qs.filter(
                     related_objects__object_id=obj.pk,
@@ -218,12 +217,12 @@ class BaseAbstractTemplate(SmartModel):
     def can_send(self, recipient, related_objects):
         return self.is_active and self.can_send_for_object(related_objects)
 
-    def get_backend_sender(self):
+    def get_controller(self):
         raise NotImplementedError
 
     def send(self, recipient, context_data, related_objects=None, tag=None, **kwargs):
         if self.can_send(recipient, related_objects):
-            return self.get_backend_sender().send(
+            return self.get_controller().send(
                 recipient=recipient,
                 content=self.render_body(context_data),
                 related_objects=related_objects,

--- a/pymess/models/dialer.py
+++ b/pymess/models/dialer.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
-from pymess.config import get_dialer_sender, settings
+from pymess.config import settings
 from pymess.utils import normalize_phone_number
 
 from .common import BaseAbstractTemplate, BaseMessage, BaseRelatedObject
@@ -92,8 +92,9 @@ class DialerMessageRelatedObject(BaseRelatedObject):
 
 class AbstractDialerTemplate(BaseAbstractTemplate):
 
-    def get_backend_sender(self):
-        return get_dialer_sender()
+    def get_controller(self):
+        from pymess.backend.dialer import DialerController
+        return DialerController()
 
     def send(self, recipient, context_data, related_objects=None, tag=None, **kwargs):
         return super().send(recipient, context_data, related_objects, tag, **kwargs)

--- a/pymess/models/push.py
+++ b/pymess/models/push.py
@@ -1,9 +1,8 @@
 from chamber.utils.datastructures import ChoicesNumEnum
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from jsonfield.fields import JSONField
 
-from pymess.config import get_push_notification_sender, settings
+from pymess.config import settings
 
 from .common import BaseAbstractTemplate, BaseMessage, BaseRelatedObject
 
@@ -65,8 +64,9 @@ class AbstractPushNotificationTemplate(BaseAbstractTemplate):
 
     heading = models.TextField(verbose_name=_('heading'))
 
-    def get_backend_sender(self):
-        return get_push_notification_sender()
+    def get_controller(self):
+        from pymess.backend.push import PushNotificationController
+        return PushNotificationController()
 
     def send(self, recipient, context_data, related_objects=None, tag=None, **kwargs):
         return super().send(recipient, context_data, related_objects, tag,

--- a/pymess/models/sms.py
+++ b/pymess/models/sms.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
-from pymess.config import settings, get_sms_sender
+from pymess.config import settings
 from pymess.utils import normalize_phone_number
 
 from .common import BaseAbstractTemplate, BaseMessage, BaseRelatedObject
@@ -68,8 +68,9 @@ class OutputSMSRelatedObject(BaseRelatedObject):
 
 class AbstractSMSTemplate(BaseAbstractTemplate):
 
-    def get_backend_sender(self):
-        return get_sms_sender()
+    def get_controller(self):
+        from pymess.backend.sms import SMSController
+        return SMSController()
 
     class Meta(BaseAbstractTemplate.Meta):
         abstract = True


### PR DESCRIPTION
in `/pymess/config.py` is `SMS_SNS_CONFIG` name so I believe it should be consistent with `SMS_OPERATOR_CONFIG`, etc.